### PR TITLE
[routing] サイト内リンクをnuxt-linkへ置換

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main-box">
   <div class="header-info">
-    <a href="https://one-chance-akb.com/notice">【時短営業】12/17まで22時閉店となります</a>
+    <nuxt-link to="/notice">【時短営業】12/17まで22時閉店となります</nuxt-link>
   </div>
     <div class="slideshow">
       <img src="../static/image/slideshow/index01.jpeg" />


### PR DESCRIPTION
サイト内リンクをNuxtJSの作法に従いnuxt-linkへ変更しました。  
ブラウザ出力はアンカータグ(<a>)となるため、既存スタイルはそのまま適用されます。  
もしアンカータグでの記述が意図した物であれば、このプルリクはrejectの上無視してください。  
TODO: 時短営業延長となったので、日付及びnotice.vueの修正が別途必要。  